### PR TITLE
Fix for building with julia 1.0

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,4 @@
 julia 0.6
 BinDeps 0.3
 Compat 1.1
-Libdl
 LazyAlgebra


### PR DESCRIPTION
Before:

julia> Pkg.clone("https://github.com/emmt/OptimPackNextGen.jl.git")
Cloning git-repo `https://github.com/emmt/OptimPackNextGen.jl.git`
Updating git-repo `https://github.com/emmt/OptimPackNextGen.jl.git`
[ Info: Assigning UUID b132a0d0-84c6-50b3-baad-5f8b1904065a to OptimPackNextGen
Resolving package versions...
ERROR: The following package names could not be resolved:
 * Libdl (8f399da3-3557-5675-b5ff-fb832c97cbdb in manifest but not in project)
Please specify by known `name=uuid`.


After removing Libdl in file REQUIRE:

julia> Pkg.clone("https://github.com/emmt/OptimPackNextGen.jl.git")
Updating registry at `~/.julia/registries/General`
Updating git-repo `https://github.com/JuliaRegistries/General.git`
Updating git-repo `https://github.com/emmt/OptimPackNextGen.jl.git`
[ Info: Assigning UUID b132a0d0-84c6-50b3-baad-5f8b1904065a to OptimPackNextGen
[ Info: Path `/home/michel/.julia/dev/OptimPackNextGen` exists and looks like the correct package, using existing path instead of cloning
Resolving package versions...
Updating `~/.julia/environments/v1.0/Project.toml`
[b132a0d0] + OptimPackNextGen v0.0.0 [`~/.julia/dev/OptimPackNextGen`]
Updating `~/.julia/environments/v1.0/Manifest.toml`
[b132a0d0] + OptimPackNextGen v0.0.0 [`~/.julia/dev/OptimPackNextGen`]
julia>